### PR TITLE
Notify user with “balloon” message when 5% of time remaining before b…

### DIFF
--- a/Take5/formMain.cs
+++ b/Take5/formMain.cs
@@ -65,7 +65,7 @@ namespace Take5
         public bool firstRun;
         private bool movedAround;
         private bool pauseWhenFullscreen, resetWhenIdle, playBeep, playTicks;
-
+        private bool notifiedAboutBreakComing;
 
         private bool userInFullscreen()
         {
@@ -147,6 +147,7 @@ namespace Take5
             {
                 minsRemain = countMins;
                 secsRemain = 0;
+                notifiedAboutBreakComing = false;
             }
         }
 
@@ -475,7 +476,16 @@ namespace Take5
                 secsRemain = 59;
 
                 if (minsRemain > 0)
+                {
+                    // check if time left has become less than 5% of total time.
+                    // if so popup up a balloon bubble to notify a break is coming soon.
+                    if (!notifiedAboutBreakComing && (double)minsRemain / countMins <= 0.05) // 0.05 is the 5%
+                    {
+                        trayIcon.ShowBalloonTip(5000, "Take5", "Break coming in " + minsRemain.ToString() + " min(s)...", ToolTipIcon.Info);
+                        notifiedAboutBreakComing = true;
+                    }
                     minsRemain--;
+                }                    
                 else
                 {
                     scrX = GetSystemMetrics(SM_CXSCREEN);
@@ -503,6 +513,8 @@ namespace Take5
                     effect = Fade.In;
                     timerFadeEffect.Enabled = true;
                     timerCountdown.Enabled = false;
+
+                    notifiedAboutBreakComing = false; // reset toggle
                 }
 
                 //save countdown as percentage in text file


### PR DESCRIPTION
…reak is reached.

Hi Stanislav,
I am just starting to take part on open source projects and learning github.
Some advice I have read is that you should start by collaborating on smaller simplifier projects before taking part in anything too big. Also the advice is that you should choose a project that you can both be passionate about and also something that you will actually use.

I have recently found one ClipBoard Manager project which I have made a few pull requests for. Now I have found this...

My current take-a-break software keeps crashing and I was never that keen on it. So it's time for something new!
I found your great little app and I'm looking forward to using it and also, if possible, adding a couple of features.

I notice that you have not worked on it for sometime but do hope that you will consider any pull requests that come from me.
If you have any comments/suggested on anything to do with my works please do let me know.
As said I'm new this open source framework so might initially make a few mistakes.

Also if you had any further ideas yourself this this app but not time to implement them yourself then let me know and I might have a go myself.

commit comments...
Notify user with “balloon” message when 5% of time remaining before break is reached
I have found this feature very useful in other “break” software as it
allows the user to prepare themselves for a upcoming break. As the event
is no longer a surprise they are more likely to take the break instead
of just ignoring the software.

I have build this in as a none configurable feature but it could be
added behind a on/off toggle config if you think some users would never
want this(?).
